### PR TITLE
fix: resolve Dependabot alerts (lockfile fixes + CDK bump)

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "@aws-cdk/integ-tests-alpha",
-      "version": "2.261.0-alpha.0",
+      "version": "2.269.0-alpha.0",
       "type": "build"
     },
     {
@@ -82,7 +82,7 @@
     },
     {
       "name": "awslint",
-      "version": "2.261.0-alpha.0",
+      "version": "2.269.0-alpha.0",
       "type": "build"
     },
     {
@@ -167,7 +167,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "^2.261.0",
+      "version": "^2.269.0",
       "type": "peer"
     },
     {

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -3,7 +3,7 @@ import { javascript } from 'projen';
 const project = new MvcCdkConstructLibrary({
   author: 'Manuel Vogel',
   authorAddress: 'info@manuel-vogel.de',
-  cdkVersion: '2.261.0', // Find the latest CDK version here: https://www.npmjs.com/package/aws-cdk-lib + https://www.npmjs.com/package/@aws-cdk/integ-runner
+  cdkVersion: '2.269.0', // Find the latest CDK version here: https://www.npmjs.com/package/aws-cdk-lib + https://www.npmjs.com/package/@aws-cdk/integ-runner
   defaultReleaseBranch: 'main',
   name: 'cdk-vscode-server',
   packageName: '@mavogel/cdk-vscode-server',

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
       },
       "devDependencies": {
         "@aws-cdk/integ-runner": "2.203.0",
-        "@aws-cdk/integ-tests-alpha": "2.261.0-alpha.0",
+        "@aws-cdk/integ-tests-alpha": "2.269.0-alpha.0",
         "@aws-sdk/client-cloudwatch": "^3.1131.0",
         "@aws-sdk/client-dynamodb": "^3.1131.0",
         "@aws-sdk/client-ec2": "^3.1131.0",
@@ -36,8 +36,8 @@
         "@types/node": "^24",
         "@typescript-eslint/eslint-plugin": "^8",
         "@typescript-eslint/parser": "^8",
-        "aws-cdk-lib": "2.261.0",
-        "awslint": "2.261.0-alpha.0",
+        "aws-cdk-lib": "2.269.0",
+        "awslint": "2.269.0-alpha.0",
         "commit-and-tag-version": "^12",
         "esbuild": "^0.28.2",
         "eslint": "^9",
@@ -60,26 +60,14 @@
         "node": ">= 24.x"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.261.0",
+        "aws-cdk-lib": "^2.269.0",
         "constructs": "^10.5.1"
       }
     },
-    "node_modules/@ampproject/remapping": {
-      "version": "2.3.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.282",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.282.tgz",
-      "integrity": "sha512-7hKMi5tTxDcKGIMIOq14PnY0GBcugW33Uh/2YHDZiEwSxLeFOCYBwhR+BFXONb/EJeVI3RETFgailNZbkcKF6g==",
+      "version": "2.2.292",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.292.tgz",
+      "integrity": "sha512-d4aMFsAFj19FtxVyw8IzlUKv5Zu4sIvgnEjI2IU6IWBJgVbJ4aFnadANqYa+6MwB1CQbGOg0jh8WE77M+Nb/9A==",
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
@@ -100,9 +88,9 @@
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "54.17.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.17.0.tgz",
-      "integrity": "sha512-wV1GmMM5AvDkiJIenb9aJcBiGTa5KwX/C/mIjFZCsWsB5b1rEMLnwMageqrOpL2mWKicpxqS8ofF/Yte4Lm3Dg==",
+      "version": "54.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.23.0.tgz",
+      "integrity": "sha512-6ymdxl2MT34iES1Qot7cWAOzJCoRMrNr/E82/eYAx1inEJXG6iqJOsoa+nTa5Q+Mk+b7Z9xLP3pc2LgNnkFJJw==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -152,16 +140,16 @@
       }
     },
     "node_modules/@aws-cdk/integ-tests-alpha": {
-      "version": "2.261.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/integ-tests-alpha/-/integ-tests-alpha-2.261.0-alpha.0.tgz",
-      "integrity": "sha512-MbhtBqHNJ67VGH9CKz/DpOSRBaclgBnTskhsnFfVjac3abaiCIGmfz0MhfQGoUC1M+xQ/imm5PQ0B/TLPX3UGw==",
+      "version": "2.269.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/integ-tests-alpha/-/integ-tests-alpha-2.269.0-alpha.0.tgz",
+      "integrity": "sha512-n6xB0ZgVg8nlpBgbaLCBSa1miwPzBhfTC4aClMDomSDB8SALbbJvrB+LLRdAlXpx6b6YA6rmZiaGqMCGBwRVxw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 20.0.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.261.0",
+        "aws-cdk-lib": "^2.269.0",
         "constructs": "^10.5.0"
       }
     },
@@ -670,13 +658,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -685,9 +673,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.0.tgz",
-      "integrity": "sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -695,22 +683,22 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.3.tgz",
-      "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.3",
-        "@babel/helper-compilation-targets": "^7.27.2",
-        "@babel/helper-module-transforms": "^7.28.3",
-        "@babel/helpers": "^7.28.3",
-        "@babel/parser": "^7.28.3",
-        "@babel/template": "^7.27.2",
-        "@babel/traverse": "^7.28.3",
-        "@babel/types": "^7.28.2",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -734,14 +722,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
-      "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.3",
-        "@babel/types": "^7.28.2",
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -751,14 +739,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.27.2",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -795,9 +783,9 @@
       "license": "ISC"
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -805,29 +793,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
-      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.28.3"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -847,9 +835,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -857,9 +845,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -867,9 +855,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -877,27 +865,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.3.tgz",
-      "integrity": "sha512-PTNtvUQihsAsDHMOP5pfobP8C6CM4JWXmP8DrEIt46c3r2bf87Ua1zoqevsMo9g+tWDwgWrFP5EIxuBx5RudAw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.2"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.3.tgz",
-      "integrity": "sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.2"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1146,33 +1134,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/parser": "^7.27.2",
-        "@babel/types": "^7.27.1"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.3.tgz",
-      "integrity": "sha512-7w4kZYHneL3A6NP2nxzHvT3HCZ7puDZZjFMqDpBPECub79sTtSO5CGXDkKrTQq8ksAwfD/XI2MRFX23njdDaIQ==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.3",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.3",
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.2",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -1180,14 +1168,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.2",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
-      "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2279,9 +2267,9 @@
       "license": "Python-2.0"
     },
     "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {
@@ -2346,35 +2334,41 @@
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.6",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
-        "@humanwhocodes/retry": "^0.3.0"
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
       },
       "engines": {
         "node": ">=18.18.0"
       }
     },
-    "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
-      "version": "0.3.1",
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=18.18"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/nzakas"
+        "node": ">=18.18.0"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {
@@ -2905,6 +2899,17 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
@@ -3564,9 +3569,9 @@
       }
     },
     "node_modules/@stylistic/eslint-plugin/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4430,7 +4435,9 @@
       "license": "MIT"
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4680,10 +4687,11 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.261.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.261.0.tgz",
-      "integrity": "sha512-e52e3Abjg0HkuRWlWwtSv5+ZiMW1rhCDdL9ff7lzWXInU8xdfLJpuoimfa0IJwjiNGyphppgg52Azx9M80OA0g==",
+      "version": "2.269.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.269.0.tgz",
+      "integrity": "sha512-Ob2EmB3faXGUMjXYhxsMvktZtaojr/aaeLqFjq9WbO+vOX1mx49OQPVB6NNNLfNKWF993Bb6nr4rsPblpUAJww==",
       "bundleDependencies": [
+        "@aws/cloudformation-validate",
         "@balena/dockerignore",
         "@aws-cdk/cloud-assembly-api",
         "case",
@@ -4698,19 +4706,20 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "2.2.282",
+        "@aws-cdk/asset-awscli-v1": "2.2.292",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.2",
-        "@aws-cdk/cloud-assembly-api": "^2.2.5",
-        "@aws-cdk/cloud-assembly-schema": "^54.0.0",
+        "@aws-cdk/cloud-assembly-api": "^2.2.6",
+        "@aws-cdk/cloud-assembly-schema": "^54.11.0",
+        "@aws/cloudformation-validate": "1.9.0-beta",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^11.3.5",
+        "fs-extra": "^11.3.6",
         "ignore": "^5.3.2",
         "jsonschema": "^1.5.0",
         "mime-types": "^2.1.35",
         "minimatch": "^10.2.5",
         "punycode": "^2.3.1",
-        "semver": "^7.8.1",
+        "semver": "^7.8.5",
         "yaml": "1.10.3"
       },
       "engines": {
@@ -4721,18 +4730,26 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
-      "version": "2.2.5",
+      "version": "2.2.6",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "jsonschema": "^1.5.0",
-        "semver": "^7.8.0"
+        "semver": "^7.8.4"
       },
       "engines": {
         "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": ">=53.28.0"
+        "@aws-cdk/cloud-assembly-schema": ">=54.5.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@aws/cloudformation-validate": {
+      "version": "1.9.0-beta",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
@@ -4749,14 +4766,14 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "5.0.6",
+      "version": "5.0.9",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/case": {
@@ -4768,7 +4785,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "11.3.5",
+      "version": "11.3.6",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4854,7 +4871,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.8.1",
+      "version": "7.8.5",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -4881,18 +4898,18 @@
       }
     },
     "node_modules/awslint": {
-      "version": "2.261.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/awslint/-/awslint-2.261.0-alpha.0.tgz",
-      "integrity": "sha512-XLVQLturD6Q4Y+zYFad5dh5bb04M4uc3VhRroL/ecb70SgdeeVRuWvHzInCbFMGPC0iR7lKU/WeMVLt7IsxS8Q==",
+      "version": "2.269.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/awslint/-/awslint-2.269.0-alpha.0.tgz",
+      "integrity": "sha512-fkelOHSUXOuXwBu8s7Bm8altoG2iaa07DVEZHlbihhJvFMSgpEGCPGVX2E/aviIxExwa6YO1++spO4jmZ9dghg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsii/spec": "1.133.0",
+        "@jsii/spec": "1.139.0",
         "chalk": "^4",
         "change-case": "^4.1.2",
         "fs-extra": "^9.1.0",
-        "jsii-reflect": "1.133.0",
-        "yargs": "^16.2.0"
+        "jsii-reflect": "1.139.0",
+        "yargs": "^16.2.2"
       },
       "bin": {
         "awslint": "bin/awslint"
@@ -4902,23 +4919,23 @@
       }
     },
     "node_modules/awslint/node_modules/@jsii/check-node": {
-      "version": "1.133.0",
-      "resolved": "https://registry.npmjs.org/@jsii/check-node/-/check-node-1.133.0.tgz",
-      "integrity": "sha512-O4vitpoZSCR8nxL+xbxN5VB49TE54CuOh4fGUzy4jZKsYzEvDGldSTicA3xsh5oVkQFdQAnQIrsd+76Xwfi0bA==",
+      "version": "1.139.0",
+      "resolved": "https://registry.npmjs.org/@jsii/check-node/-/check-node-1.139.0.tgz",
+      "integrity": "sha512-tLS0H2XPN3hWVO9OtVB2DDllaxz3M6Jz8Zk8ByV1pl2h5b6LayJg8lHYvRMf0b3P/82xqWat7CpfLeqU96OwVw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^4.1.2",
-        "semver": "^7.8.1"
+        "semver": "^7.8.5"
       },
       "engines": {
         "node": ">= 14.17.0"
       }
     },
     "node_modules/awslint/node_modules/@jsii/spec": {
-      "version": "1.133.0",
-      "resolved": "https://registry.npmjs.org/@jsii/spec/-/spec-1.133.0.tgz",
-      "integrity": "sha512-U6LSoWV/0yYunjEvHTMf4+aL+v3UCh3+n+1qE0al1vVcobt0CDXpNF/NIERNjZDuCY0w5Oxo1U25dUrm4D8n7g==",
+      "version": "1.139.0",
+      "resolved": "https://registry.npmjs.org/@jsii/spec/-/spec-1.139.0.tgz",
+      "integrity": "sha512-+l1B0h4WAg6KOQ7PGykW/FvxeFmyt74U0/n41cus9Jdjv3VfQJKynsv5r9Ng23B1KwWqJkS5YvJuv2yGYoULdw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -4955,18 +4972,18 @@
       }
     },
     "node_modules/awslint/node_modules/jsii-reflect": {
-      "version": "1.133.0",
-      "resolved": "https://registry.npmjs.org/jsii-reflect/-/jsii-reflect-1.133.0.tgz",
-      "integrity": "sha512-lmN427bEQKjGkbI7KzyA7CGqna+5nZA46P1+rEFQqsWr3LFlB84arK6bxcI7UgVSnLt4Ke4Rq5sVLf7aukBn6Q==",
+      "version": "1.139.0",
+      "resolved": "https://registry.npmjs.org/jsii-reflect/-/jsii-reflect-1.139.0.tgz",
+      "integrity": "sha512-Z8rGDzykcg6REfFV8HJZ0oms5zi8wBO4T7B5thSS4iME0osbWJP62pFn2yT6VivOESKnkFZOI3RkIKYkynPbGg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsii/check-node": "1.133.0",
-        "@jsii/spec": "1.133.0",
+        "@jsii/check-node": "1.139.0",
+        "@jsii/spec": "1.139.0",
         "chalk": "^4",
         "fs-extra": "^10.1.0",
-        "oo-ascii-tree": "^1.133.0",
-        "yargs": "^17.7.2"
+        "oo-ascii-tree": "^1.139.0",
+        "yargs": "^17.7.3"
       },
       "bin": {
         "jsii-query": "bin/jsii-query",
@@ -5124,6 +5141,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.23",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.23.tgz",
+      "integrity": "sha512-le521dGVfxM7yRX0EikCoSz+rOK+hHzdDt/E7mG1jOJB/6WAAUuwVroLwaB7ApaUsz5Q0kFlDXLSA9MheUIfRQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "inBundle": true,
@@ -5171,9 +5201,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.25.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.2.tgz",
-      "integrity": "sha512-0si2SJK3ooGzIawRu61ZdPCO1IncZwS8IzuX73sPZsXW6EQ/w/DAfPyKI8l1ETTCr2MnvqWitmlCUxgdul45jA==",
+      "version": "4.28.9",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.9.tgz",
+      "integrity": "sha512-EWazOblFYUvlGZcfGhPUPmYh3nikUxBVb+y9MJun5f3hBi812X+8MSQTujLBtgK3cf51fJWbWfOjyeO954d+Eg==",
       "dev": true,
       "funding": [
         {
@@ -5191,10 +5221,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001733",
-        "electron-to-chromium": "^1.5.199",
-        "node-releases": "^2.0.19",
-        "update-browserslist-db": "^1.1.3"
+        "baseline-browser-mapping": "^2.11.20",
+        "caniuse-lite": "^1.0.30001810",
+        "electron-to-chromium": "^1.5.420",
+        "node-releases": "^2.0.54",
+        "update-browserslist-db": "^1.3.2"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -5332,9 +5363,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001735",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001735.tgz",
-      "integrity": "sha512-EV/laoX7Wq2J9TQlyIXRxTJqIw4sxfXS4OYgudGxBYRuTv0q7AM6yMEpU/Vo1I94thg9U6EZ2NfZx9GJq83u7w==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "dev": true,
       "funding": [
         {
@@ -6142,10 +6173,20 @@
       "license": "Python-2.0"
     },
     "node_modules/cosmiconfig/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -6400,7 +6441,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "4.0.2",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -6572,9 +6615,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.202",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.202.tgz",
-      "integrity": "sha512-NxbYjRmiHcHXV1Ws3fWUW+SLb62isauajk45LUJ/HgIOkUA7jLZu/X2Iif+X9FBNK8QkF9Zb4Q2mcwXCcY30mg==",
+      "version": "1.5.427",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.427.tgz",
+      "integrity": "sha512-n14zb3FdsChZ2BNobqNHAJMcP3ifFv4paox2LvCrfVAQcqGiSURgbJl+PfMpHVCNFkStnNc+RRVtPBTVW5PDgw==",
       "dev": true,
       "license": "ISC"
     },
@@ -7345,7 +7388,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.0.6",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
       "funding": [
         {
@@ -7490,7 +7535,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.2",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
       "dev": true,
       "license": "ISC"
     },
@@ -9250,9 +9297,9 @@
       }
     },
     "node_modules/jest-util/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9697,6 +9744,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/jsii-rosetta/node_modules/stream-chain": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-2.2.5.tgz",
+      "integrity": "sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/jsii-rosetta/node_modules/stream-json": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-1.9.1.tgz",
+      "integrity": "sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "stream-chain": "^2.2.5"
+      }
+    },
     "node_modules/jsii-rosetta/node_modules/yargs": {
       "version": "17.7.3",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
@@ -10123,9 +10187,9 @@
       }
     },
     "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10259,11 +10323,14 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+      "version": "2.0.55",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.55.tgz",
+      "integrity": "sha512-mIrE/Cw9y+9Au6dS5vDKDhQza9YvG6w+ZrS6X+ZzA7yFW/soAeaups4Qzn1bL6g5FVy8WtP79+0j82oPIbqRjQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
@@ -10695,7 +10762,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12171,19 +12240,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/stream-chain": {
-      "version": "2.2.5",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/stream-json": {
-      "version": "1.9.1",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "stream-chain": "^2.2.5"
-      }
-    },
     "node_modules/streamroller": {
       "version": "3.1.5",
       "dev": true,
@@ -12663,9 +12719,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13054,9 +13110,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.3.tgz",
+      "integrity": "sha512-pJ2sYawQS0R/WI928Gj5GlPhTGzbMelq0+4INtSYNDV9ErKJcX6xjGWkoG/VnB3dpUm00zALaqkrUD77pO5TDQ==",
       "dev": true,
       "funding": [
         {
@@ -13377,14 +13433,19 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.7.0",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.1.tgz",
+      "integrity": "sha512-3NxN8+78OdzbT7C/WjGsyfPAtJaN3FNDsWxv7Y7mcDsT/oOmgW8BpyQQFFBnvZE3j9Y2Sdz1ULFLezL7Eb2yFw==",
       "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@aws-cdk/integ-runner": "2.203.0",
-    "@aws-cdk/integ-tests-alpha": "2.261.0-alpha.0",
+    "@aws-cdk/integ-tests-alpha": "2.269.0-alpha.0",
     "@aws-sdk/client-cloudwatch": "^3.1131.0",
     "@aws-sdk/client-dynamodb": "^3.1131.0",
     "@aws-sdk/client-ec2": "^3.1131.0",
@@ -67,8 +67,8 @@
     "@types/node": "^24",
     "@typescript-eslint/eslint-plugin": "^8",
     "@typescript-eslint/parser": "^8",
-    "aws-cdk-lib": "2.261.0",
-    "awslint": "2.261.0-alpha.0",
+    "aws-cdk-lib": "2.269.0",
+    "awslint": "2.269.0-alpha.0",
     "commit-and-tag-version": "^12",
     "esbuild": "^0.28.2",
     "eslint": "^9",
@@ -88,7 +88,7 @@
     "typescript": "^6.0.2"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.261.0",
+    "aws-cdk-lib": "^2.269.0",
     "constructs": "^10.5.1"
   },
   "dependencies": {

--- a/test/__snapshots__/vscode-server.test.ts.snap
+++ b/test/__snapshots__/vscode-server.test.ts.snap
@@ -49,7 +49,7 @@ exports[`vscode-server vscode-server-custom-props 1`] = `
       ],
       "Properties": {
         "Code": {
-          "S3Bucket": "cdk-hnb659fds-assets-1234-us-east-1",
+          "S3Bucket": "cdk-hnb659fds-assets-123456789012-us-east-1",
           "S3Key": "9b8fce7ae7f25ef82fdbaf6b72523b99d0875c0c9c826642819fb51f11d9b125.zip",
         },
         "Handler": "index.handler",
@@ -76,7 +76,7 @@ exports[`vscode-server vscode-server-custom-props 1`] = `
       ],
       "Properties": {
         "Code": {
-          "S3Bucket": "cdk-hnb659fds-assets-1234-us-east-1",
+          "S3Bucket": "cdk-hnb659fds-assets-123456789012-us-east-1",
           "S3Key": "2f99f38311da357eaaea1284d67c759759324dec4a1cd11621d9c59eea9e81df.zip",
         },
         "Description": "src/installer/installer.lambda.ts",
@@ -109,7 +109,7 @@ exports[`vscode-server vscode-server-custom-props 1`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":ssm:us-east-1:1234:document/vscode-server-ubuntu-testStack",
+                      ":ssm:us-east-1:123456789012:document/vscode-server-ubuntu-testStack",
                     ],
                   ],
                 },
@@ -121,7 +121,7 @@ exports[`vscode-server vscode-server-custom-props 1`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":ssm:us-east-1:1234:document/AmazonCloudWatch-ManageAgent",
+                      ":ssm:us-east-1:123456789012:document/AmazonCloudWatch-ManageAgent",
                     ],
                   ],
                 },
@@ -133,7 +133,7 @@ exports[`vscode-server vscode-server-custom-props 1`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":ec2:us-east-1:1234:instance/",
+                      ":ec2:us-east-1:123456789012:instance/",
                       {
                         "Ref": "testVSCodeServerserverinstance48076E15",
                       },
@@ -200,7 +200,7 @@ exports[`vscode-server vscode-server-custom-props 1`] = `
       ],
       "Properties": {
         "Code": {
-          "S3Bucket": "cdk-hnb659fds-assets-1234-us-east-1",
+          "S3Bucket": "cdk-hnb659fds-assets-123456789012-us-east-1",
           "S3Key": "e16ffb3b34af185b8b30c88fdb19faa13b6c42bb38580485c4e84b384ee48b63.zip",
         },
         "Description": "AWS CDK resource provider framework - onEvent (testStack/testVSCodeServer/InstallerProvider)",
@@ -345,7 +345,7 @@ exports[`vscode-server vscode-server-custom-props 1`] = `
       ],
       "Properties": {
         "Code": {
-          "S3Bucket": "cdk-hnb659fds-assets-1234-us-east-1",
+          "S3Bucket": "cdk-hnb659fds-assets-123456789012-us-east-1",
           "S3Key": "e16ffb3b34af185b8b30c88fdb19faa13b6c42bb38580485c4e84b384ee48b63.zip",
         },
         "Description": "AWS CDK resource provider framework - onEvent (testStack/testVSCodeServer/SecretRetrieveProvider)",
@@ -482,7 +482,7 @@ exports[`vscode-server vscode-server-custom-props 1`] = `
       ],
       "Properties": {
         "Code": {
-          "S3Bucket": "cdk-hnb659fds-assets-1234-us-east-1",
+          "S3Bucket": "cdk-hnb659fds-assets-123456789012-us-east-1",
           "S3Key": "781ab0ab74634cdaf61539ab208ab777829ef07097ac21f95b9e15a3b1eedc1b.zip",
         },
         "Description": "src/secret-retriever/secret-retriever.lambda.ts",
@@ -1018,7 +1018,7 @@ exports[`vscode-server vscode-server-custom-props 1`] = `
                     "iam:UpdateRoleDescription",
                   ],
                   "Effect": "Allow",
-                  "Resource": "arn:aws:iam::1234:role/cdk-*",
+                  "Resource": "arn:aws:iam::123456789012:role/cdk-*",
                   "Sid": "StsAccess",
                 },
                 {
@@ -1029,12 +1029,12 @@ exports[`vscode-server vscode-server-custom-props 1`] = `
                     },
                   },
                   "Effect": "Allow",
-                  "Resource": "arn:aws:iam::1234:role/cdk-*",
+                  "Resource": "arn:aws:iam::123456789012:role/cdk-*",
                 },
                 {
                   "Action": "cloudformation:*",
                   "Effect": "Allow",
-                  "Resource": "arn:aws:cloudformation:*:1234:stack/CDKToolkit/*",
+                  "Resource": "arn:aws:cloudformation:*:123456789012:stack/CDKToolkit/*",
                 },
                 {
                   "Action": [
@@ -1062,7 +1062,7 @@ exports[`vscode-server vscode-server-custom-props 1`] = `
                     "ecr:DeleteRepository",
                   ],
                   "Effect": "Allow",
-                  "Resource": "arn:aws:ecr:*:1234:repository/cdk-*",
+                  "Resource": "arn:aws:ecr:*:123456789012:repository/cdk-*",
                   "Sid": "ECRAccess",
                 },
                 {
@@ -1072,7 +1072,7 @@ exports[`vscode-server vscode-server-custom-props 1`] = `
                     "ssm:DeleteParameter*",
                   ],
                   "Effect": "Allow",
-                  "Resource": "arn:aws:ssm:*:1234:parameter/cdk-bootstrap/*",
+                  "Resource": "arn:aws:ssm:*:123456789012:parameter/cdk-bootstrap/*",
                 },
                 {
                   "Action": [
@@ -1092,12 +1092,12 @@ exports[`vscode-server vscode-server-custom-props 1`] = `
                     "codepipeline:UpdatePipeline",
                   ],
                   "Effect": "Allow",
-                  "Resource": "arn:aws:codepipeline:*:1234:*/*",
+                  "Resource": "arn:aws:codepipeline:*:123456789012:*/*",
                 },
                 {
                   "Action": "kms:Decrypt",
                   "Effect": "Allow",
-                  "Resource": "arn:aws:kms:*:1234:key/*",
+                  "Resource": "arn:aws:kms:*:123456789012:key/*",
                 },
               ],
               "Version": "2012-10-17",
@@ -1199,7 +1199,7 @@ EOF",
                   "echo 'PATH=$PATH:/home/participant/.local/bin' >> /home/participant/.bashrc",
                   "echo 'export PATH' >> /home/participant/.bashrc",
                   "echo 'export AWS_REGION=us-east-1' >> /home/participant/.bashrc",
-                  "echo 'export AWS_ACCOUNTID=1234' >> /home/participant/.bashrc",
+                  "echo 'export AWS_ACCOUNTID=123456789012' >> /home/participant/.bashrc",
                   "echo 'export NEXT_TELEMETRY_DISABLED=1' >> /home/participant/.bashrc",
                   "echo "export PS1='\\[\\033[01;32m\\]\\u:\\[\\033[01;34m\\]\\w\\[\\033[00m\\]\\$ '" >> /home/participant/.bashrc",
                   "chown -R participant:participant /home/participant",
@@ -1967,7 +1967,7 @@ exports[`vscode-server vscode-server-default-props 1`] = `
       ],
       "Properties": {
         "Code": {
-          "S3Bucket": "cdk-hnb659fds-assets-1234-us-east-1",
+          "S3Bucket": "cdk-hnb659fds-assets-123456789012-us-east-1",
           "S3Key": "9b8fce7ae7f25ef82fdbaf6b72523b99d0875c0c9c826642819fb51f11d9b125.zip",
         },
         "Handler": "index.handler",
@@ -1994,7 +1994,7 @@ exports[`vscode-server vscode-server-default-props 1`] = `
       ],
       "Properties": {
         "Code": {
-          "S3Bucket": "cdk-hnb659fds-assets-1234-us-east-1",
+          "S3Bucket": "cdk-hnb659fds-assets-123456789012-us-east-1",
           "S3Key": "2f99f38311da357eaaea1284d67c759759324dec4a1cd11621d9c59eea9e81df.zip",
         },
         "Description": "src/installer/installer.lambda.ts",
@@ -2027,7 +2027,7 @@ exports[`vscode-server vscode-server-default-props 1`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":ssm:us-east-1:1234:document/vscode-server-ubuntu-testStack",
+                      ":ssm:us-east-1:123456789012:document/vscode-server-ubuntu-testStack",
                     ],
                   ],
                 },
@@ -2039,7 +2039,7 @@ exports[`vscode-server vscode-server-default-props 1`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":ssm:us-east-1:1234:document/AmazonCloudWatch-ManageAgent",
+                      ":ssm:us-east-1:123456789012:document/AmazonCloudWatch-ManageAgent",
                     ],
                   ],
                 },
@@ -2051,7 +2051,7 @@ exports[`vscode-server vscode-server-default-props 1`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":ec2:us-east-1:1234:instance/",
+                      ":ec2:us-east-1:123456789012:instance/",
                       {
                         "Ref": "testVSCodeServerserverinstance48076E15",
                       },
@@ -2118,7 +2118,7 @@ exports[`vscode-server vscode-server-default-props 1`] = `
       ],
       "Properties": {
         "Code": {
-          "S3Bucket": "cdk-hnb659fds-assets-1234-us-east-1",
+          "S3Bucket": "cdk-hnb659fds-assets-123456789012-us-east-1",
           "S3Key": "e16ffb3b34af185b8b30c88fdb19faa13b6c42bb38580485c4e84b384ee48b63.zip",
         },
         "Description": "AWS CDK resource provider framework - onEvent (testStack/testVSCodeServer/InstallerProvider)",
@@ -2263,7 +2263,7 @@ exports[`vscode-server vscode-server-default-props 1`] = `
       ],
       "Properties": {
         "Code": {
-          "S3Bucket": "cdk-hnb659fds-assets-1234-us-east-1",
+          "S3Bucket": "cdk-hnb659fds-assets-123456789012-us-east-1",
           "S3Key": "e16ffb3b34af185b8b30c88fdb19faa13b6c42bb38580485c4e84b384ee48b63.zip",
         },
         "Description": "AWS CDK resource provider framework - onEvent (testStack/testVSCodeServer/SecretRetrieveProvider)",
@@ -2400,7 +2400,7 @@ exports[`vscode-server vscode-server-default-props 1`] = `
       ],
       "Properties": {
         "Code": {
-          "S3Bucket": "cdk-hnb659fds-assets-1234-us-east-1",
+          "S3Bucket": "cdk-hnb659fds-assets-123456789012-us-east-1",
           "S3Key": "781ab0ab74634cdaf61539ab208ab777829ef07097ac21f95b9e15a3b1eedc1b.zip",
         },
         "Description": "src/secret-retriever/secret-retriever.lambda.ts",
@@ -2916,7 +2916,7 @@ exports[`vscode-server vscode-server-default-props 1`] = `
                     "iam:UpdateRoleDescription",
                   ],
                   "Effect": "Allow",
-                  "Resource": "arn:aws:iam::1234:role/cdk-*",
+                  "Resource": "arn:aws:iam::123456789012:role/cdk-*",
                   "Sid": "StsAccess",
                 },
                 {
@@ -2927,12 +2927,12 @@ exports[`vscode-server vscode-server-default-props 1`] = `
                     },
                   },
                   "Effect": "Allow",
-                  "Resource": "arn:aws:iam::1234:role/cdk-*",
+                  "Resource": "arn:aws:iam::123456789012:role/cdk-*",
                 },
                 {
                   "Action": "cloudformation:*",
                   "Effect": "Allow",
-                  "Resource": "arn:aws:cloudformation:*:1234:stack/CDKToolkit/*",
+                  "Resource": "arn:aws:cloudformation:*:123456789012:stack/CDKToolkit/*",
                 },
                 {
                   "Action": [
@@ -2960,7 +2960,7 @@ exports[`vscode-server vscode-server-default-props 1`] = `
                     "ecr:DeleteRepository",
                   ],
                   "Effect": "Allow",
-                  "Resource": "arn:aws:ecr:*:1234:repository/cdk-*",
+                  "Resource": "arn:aws:ecr:*:123456789012:repository/cdk-*",
                   "Sid": "ECRAccess",
                 },
                 {
@@ -2970,7 +2970,7 @@ exports[`vscode-server vscode-server-default-props 1`] = `
                     "ssm:DeleteParameter*",
                   ],
                   "Effect": "Allow",
-                  "Resource": "arn:aws:ssm:*:1234:parameter/cdk-bootstrap/*",
+                  "Resource": "arn:aws:ssm:*:123456789012:parameter/cdk-bootstrap/*",
                 },
                 {
                   "Action": [
@@ -2990,12 +2990,12 @@ exports[`vscode-server vscode-server-default-props 1`] = `
                     "codepipeline:UpdatePipeline",
                   ],
                   "Effect": "Allow",
-                  "Resource": "arn:aws:codepipeline:*:1234:*/*",
+                  "Resource": "arn:aws:codepipeline:*:123456789012:*/*",
                 },
                 {
                   "Action": "kms:Decrypt",
                   "Effect": "Allow",
-                  "Resource": "arn:aws:kms:*:1234:key/*",
+                  "Resource": "arn:aws:kms:*:123456789012:key/*",
                 },
               ],
               "Version": "2012-10-17",
@@ -3097,7 +3097,7 @@ EOF",
                   "echo 'PATH=$PATH:/home/participant/.local/bin' >> /home/participant/.bashrc",
                   "echo 'export PATH' >> /home/participant/.bashrc",
                   "echo 'export AWS_REGION=us-east-1' >> /home/participant/.bashrc",
-                  "echo 'export AWS_ACCOUNTID=1234' >> /home/participant/.bashrc",
+                  "echo 'export AWS_ACCOUNTID=123456789012' >> /home/participant/.bashrc",
                   "echo 'export NEXT_TELEMETRY_DISABLED=1' >> /home/participant/.bashrc",
                   "echo "export PS1='\\[\\033[01;32m\\]\\u:\\[\\033[01;34m\\]\\w\\[\\033[00m\\]\\$ '" >> /home/participant/.bashrc",
                   "chown -R participant:participant /home/participant",

--- a/test/vscode-server.test.ts
+++ b/test/vscode-server.test.ts
@@ -12,7 +12,7 @@ describe('vscode-server', () => {
     const stack = new Stack(app, 'testStack', {
       env: {
         region: 'us-east-1',
-        account: '1234',
+        account: '123456789012',
       },
     });
 
@@ -29,7 +29,7 @@ describe('vscode-server', () => {
     const stack = new Stack(app, 'testStack', {
       env: {
         region: 'us-east-1',
-        account: '1234',
+        account: '123456789012',
       },
     });
 
@@ -52,7 +52,7 @@ describe('vscode-server-custom-domain', () => {
     const stack = new Stack(app, 'testStack', {
       env: {
         region: 'us-east-1',
-        account: '1234',
+        account: '123456789012',
       },
     });
 
@@ -79,7 +79,7 @@ describe('vscode-server-custom-domain', () => {
     const stack = new Stack(app, 'testStack', {
       env: {
         region: 'us-east-1',
-        account: '1234',
+        account: '123456789012',
       },
     });
 
@@ -110,7 +110,7 @@ describe('vscode-server-custom-domain', () => {
     const stack = new Stack(app, 'testStack', {
       env: {
         region: 'us-east-1',
-        account: '1234',
+        account: '123456789012',
       },
     });
 
@@ -142,7 +142,7 @@ describe('vscode-server-custom-domain', () => {
     const stack = new Stack(app, 'testStack', {
       env: {
         region: 'us-east-1',
-        account: '1234',
+        account: '123456789012',
       },
     });
 
@@ -179,7 +179,7 @@ describe('vscode-server-custom-domain', () => {
     const stack = new Stack(app, 'testStack', {
       env: {
         region: 'us-east-1',
-        account: '1234',
+        account: '123456789012',
       },
     });
 
@@ -197,7 +197,7 @@ describe('vscode-server-custom-domain', () => {
     const stack = new Stack(app, 'testStack', {
       env: {
         region: 'us-east-1',
-        account: '1234',
+        account: '123456789012',
       },
     });
 
@@ -218,7 +218,7 @@ describe('vscode-server-custom-domain', () => {
     const stack = new Stack(app, 'testStack', {
       env: {
         region: 'us-east-1',
-        account: '1234',
+        account: '123456789012',
       },
     });
 
@@ -248,7 +248,7 @@ describe('vscode-server-custom-domain', () => {
     const stack = new Stack(app, 'testStack', {
       env: {
         region: 'us-east-1',
-        account: '1234',
+        account: '123456789012',
       },
     });
 
@@ -272,7 +272,7 @@ describe('vscode-server-cdk-nag-AwsSolutions-Pack', () => {
     stack = new Stack(app, 'testStack', {
       env: {
         region: 'us-east-1',
-        account: '1234',
+        account: '123456789012',
       },
     });
 
@@ -385,7 +385,7 @@ describe('vscode-server-auto-stop', () => {
     const stack = new Stack(app, 'testStack', {
       env: {
         region: 'us-east-1',
-        account: '1234',
+        account: '123456789012',
       },
     });
 
@@ -423,7 +423,7 @@ describe('vscode-server-auto-stop', () => {
     const stack = new Stack(app, 'testStack', {
       env: {
         region: 'us-east-1',
-        account: '1234',
+        account: '123456789012',
       },
     });
 
@@ -451,7 +451,7 @@ describe('vscode-server-auto-stop', () => {
     const stack = new Stack(app, 'testStack', {
       env: {
         region: 'us-east-1',
-        account: '1234',
+        account: '123456789012',
       },
     });
 
@@ -478,7 +478,7 @@ describe('vscode-server-auto-stop', () => {
     const stack = new Stack(app, 'testStack', {
       env: {
         region: 'us-east-1',
-        account: '1234',
+        account: '123456789012',
       },
     });
 
@@ -506,7 +506,7 @@ describe('vscode-server-auto-stop', () => {
     const stack = new Stack(app, 'testStack', {
       env: {
         region: 'us-east-1',
-        account: '1234',
+        account: '123456789012',
       },
     });
 
@@ -532,7 +532,7 @@ describe('vscode-server-custom-install-steps', () => {
     const stack = new Stack(app, 'testStack', {
       env: {
         region: 'us-east-1',
-        account: '1234',
+        account: '123456789012',
       },
     });
 
@@ -594,7 +594,7 @@ describe('vscode-server-custom-install-steps', () => {
     const stack = new Stack(app, 'testStack', {
       env: {
         region: 'us-east-1',
-        account: '1234',
+        account: '123456789012',
       },
     });
 
@@ -613,7 +613,7 @@ describe('vscode-server-custom-install-steps', () => {
     const stack = new Stack(app, 'testStack', {
       env: {
         region: 'us-east-1',
-        account: '1234',
+        account: '123456789012',
       },
     });
 
@@ -636,7 +636,7 @@ describe('vscode-server-installer-kiro-cli', () => {
     const stack = new Stack(app, 'testStack', {
       env: {
         region: 'us-east-1',
-        account: '1234',
+        account: '123456789012',
       },
     });
 
@@ -661,7 +661,7 @@ describe('vscode-server-installer-kiro-cli', () => {
     const stack = new Stack(app, 'testStack', {
       env: {
         region: 'us-east-1',
-        account: '1234',
+        account: '123456789012',
       },
     });
 


### PR DESCRIPTION
## Summary
Resolves 21 of the 22 open Dependabot alerts.

- `npm audit fix` resolved the js-yaml, fast-uri, picomatch, flatted, ajv, and `@humanfs/node` transitive vulnerabilities.
- Bumped `cdkVersion` 2.261.0 → 2.269.0 in `.projenrc.ts`. The npm-resolved `brace-expansion` copy was already fixed by `npm audit fix`, but a second, *bundled* copy of `brace-expansion` ships inside `aws-cdk-lib` itself and can't be overridden via the lockfile — only a newer `aws-cdk-lib` (which now uses `minimatch` instead) removes it.
- The CDK bump pulled in a new built-in "CloudFormation Validate" synthesis plugin, which surfaced two pre-existing test-fixture issues in `test/vscode-server.test.ts`: a non-12-digit dummy AWS account id (`1234` → `123456789012`) and a lambda runtime nearing deprecation. Fixed the account id and regenerated the two affected snapshots.

## Not fixed (1 alert left open, documented)
**Alert #108 — `stream-json` (moderate).** `jsii-rosetta` pins `stream-json@^1.9.1` and never resolves past that vulnerable 1.x line, even on jsii-rosetta's latest release. I tried forcing the patched 3.x via an npm `overrides` entry, but it broke `npx projen build`: `jsii-docgen` failed because stream-json 3.x's package `exports` map (`./* → ./src/*`) no longer resolves jsii-rosetta's extensionless deep import (`require('stream-json/Assembler')`). This is a structural incompatibility, not a simple version bump, and needs an upstream fix in jsii-rosetta. Left the alert open rather than break docgen.

## Verification
`npx projen build` (compile, unit tests, docgen, awslint, packaging) passes end to end. `npm audit` drops from 22 open findings to 4 moderate findings, all part of the single documented stream-json chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)